### PR TITLE
Add Icon for macOS

### DIFF
--- a/src/PoshNotify.psd1
+++ b/src/PoshNotify.psd1
@@ -21,19 +21,19 @@ CompatiblePSEditions = @('Desktop', 'Core')
 GUID = '742f6d08-546a-4598-8155-fab499b3c1c0'
 
 # Author of this module
-Author = 'idk'
+Author = 'windos;steviecoaster;tylerleonhardt'
 
 # Company or vendor of this module
-CompanyName = 'idk'
+CompanyName = 'Windos, steviecoaster & tylerleonhardt'
 
 # Copyright statement for this module
-Copyright = '(c) idk. All rights reserved.'
+Copyright = '(c) Windos, steviecoaster & tylerleonhardt. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Cross-platform PowerShell module for generating toast notifications on Linux, macOS, and Windows.'
 
 # Minimum version of the PowerShell engine required by this module
-# PowerShellVersion = ''
+PowerShellVersion = '5.1'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''
@@ -69,7 +69,7 @@ RequiredModules = @('MacNotify')
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Send-PoshNotification'
+FunctionsToExport = 'Send-OSNotification'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = ''

--- a/src/Private/Pop-MacOSNotification.ps1
+++ b/src/Private/Pop-MacOSNotification.ps1
@@ -8,8 +8,32 @@ function Pop-MacOSNotification {
 
         [Parameter(Mandatory=$true)]
         [string]
-        $Title
+        $Title,
+
+        [Parameter()]
+        [string]
+        $Icon
     )
 
-    MacNotify\Invoke-MacNotification -Message $Body -Title $Title
+    # If the command requires advanced features, we should use alerter.
+    # This if contains all the parameters that would need it.
+    if ($Icon) {
+        $splat = @{
+            Message = $Body
+            Title = $Title
+            Timeout = 4
+            Silent = $true
+        }
+
+        if ($Icon) {
+            $splat.Add('AppIcon', $Icon)
+        }
+        MacNotify\Invoke-AlerterNotification @splat
+    } else {
+        $splat = @{
+            Message = $Body
+            Title = $Title
+        }
+        MacNotify\Invoke-MacNotification @splat
+    }
 }

--- a/src/Public/Send-OSNotification.ps1
+++ b/src/Public/Send-OSNotification.ps1
@@ -41,11 +41,7 @@ function Send-OSNotification {
             break
         }
         $IsMacOS {
-            if ($Icon) {
-                Write-Warning 'MacOS does not support the Icon parameter at this time.'
-            }
-
-            Pop-MacOSNotification -Body $Body -Title $Title
+            Pop-MacOSNotification -Body $Body -Title $Title -Icon $Icon
             break
         }
         $IsLinux {


### PR DESCRIPTION
Also actually makes the module work - forgot to change the psd1 `Send-PoshNotification` -> `Send-OSNotification` lol

Since `Invoke-AlerterNotification` blocks (because the util it uses `alerter` blocks) waiting for the notification to be dismissed, I have it time out after 4 seconds and return nothing. We could have this running in a background job... but I felt like that was a bit too much overhead.

Eventually when we add support for responses (macOS & Windows only probably) we can handle this differently