### PR TITLE
Support ShouldProcess

### DIFF
--- a/src/Private/ConvertTo-ParameterString.ps1
+++ b/src/Private/ConvertTo-ParameterString.ps1
@@ -1,0 +1,22 @@
+# A helper function to best-effort convert a hashtable that will be splatted, to a param string
+# ex. -Body 'Hello World' -Timeout 4
+function ConvertTo-ParameterString {
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory=$true)]
+        [hashtable]
+        $InputObject
+    )
+    $paramsArray = @()
+    foreach ($dictionaryEntry in $InputObject.GetEnumerator()) {
+        $paramsArray += "-$($dictionaryEntry.Key)"
+
+        if ($dictionaryEntry.Value.GetType() -eq [string]) {
+            $paramsArray += "'$($dictionaryEntry.Value)'"
+        } else {
+            $paramsArray += "$($dictionaryEntry.Value)"
+        }
+    }
+
+    $paramsArray -join ' '
+}

--- a/src/Private/Pop-MacOSNotification.ps1
+++ b/src/Private/Pop-MacOSNotification.ps1
@@ -1,6 +1,6 @@
 # The function that handles macOS notifications
 function Pop-MacOSNotification {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]
@@ -28,12 +28,16 @@ function Pop-MacOSNotification {
         if ($Icon) {
             $splat.Add('AppIcon', $Icon)
         }
-        MacNotify\Invoke-AlerterNotification @splat
+        if($PSCmdlet.ShouldProcess("running: Invoke-AlerterNotification $(ConvertTo-ParameterString $splat)")) {
+            MacNotify\Invoke-AlerterNotification @splat
+        }
     } else {
         $splat = @{
             Message = $Body
             Title = $Title
         }
-        MacNotify\Invoke-MacNotification @splat
+        if($PSCmdlet.ShouldProcess("rrunning: Invoke-MacNotification $(ConvertTo-ParameterString $splat)")) {
+            MacNotify\Invoke-MacNotification @splat
+        }
     }
 }

--- a/src/Public/Send-OSNotification.ps1
+++ b/src/Public/Send-OSNotification.ps1
@@ -21,7 +21,7 @@ An example
 General notes
 #>
 function Send-OSNotification {
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess=$true)]
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [string]


### PR DESCRIPTION
Now, if you do:

```powershell
Send-OSNotification "hello world" -Icon /Users/tyler/Pictures/seattle.jpg -WhatIf
```

you get:

```
What if: Performing the operation "Pop-MacOSNotification" on target "running: Invoke-AlerterNotification -Title 'PowerShell Notification' -Silent True -Timeout 4 -AppIcon '/Users/tyler/Pictures/seattle.jpg' -Message 'hello world'".
```

and the notification does not appear. This might be a potential testing opportunity.