### PR TITLE
Initial Linux support

### DIFF
--- a/src/PoshNotify.psd1
+++ b/src/PoshNotify.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('MacNotify')
+RequiredModules = @('MacNotify', 'PSNotifySend')
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/src/Private/Pop-LinuxNotification.ps1
+++ b/src/Private/Pop-LinuxNotification.ps1
@@ -1,0 +1,30 @@
+# The function that handles Linux notifications
+function Pop-LinuxNotification {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [string]
+        $Body,
+
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Title,
+
+        [Parameter()]
+        [string]
+        $Icon
+    )
+
+    $splat = @{
+        Body = $Body
+        Summary = $Title
+    }
+
+    if ($Icon) {
+        $splat.Add('Icon', $Icon)
+    }
+
+    if($PSCmdlet.ShouldProcess("running: PSNotifySend\Send-PSNotification $(ConvertTo-ParameterString $splat)")) {
+        PSNotifySend\Send-PSNotification @splat
+    }
+}

--- a/src/Public/Send-OSNotification.ps1
+++ b/src/Public/Send-OSNotification.ps1
@@ -45,6 +45,7 @@ function Send-OSNotification {
             break
         }
         $IsLinux {
+            Pop-LinuxNotification -Body $Body -Title $Title -Icon $Icon
             break
         }
         Default {


### PR DESCRIPTION
:tada: 

Supports: Title, Body, Icon...


Icon is a little weird on some Linux distros... sometimes they have to  be in:

```
~/.local/share/icons/
```

in order to work... others will accept path...

In either case, I think I need to handle if the icon doesn't exist in PSNotifySend and not PoshNotify so I think this PR is good.