### PR TITLE
Add calls to Pop-WindowsNotification

### DIFF
--- a/src/Public/Send-OSNotification.ps1
+++ b/src/Public/Send-OSNotification.ps1
@@ -38,6 +38,8 @@ function Send-OSNotification {
 
     switch ($true) {
         $IsWindows {
+            # Must be PowerShell Core on Windows
+            Pop-WindowsNotification -Body $Body -Title $Title -Icon $Icon
             break
         }
         $IsMacOS {
@@ -50,6 +52,7 @@ function Send-OSNotification {
         }
         Default {
             # Must be Windows PowerShell
+            Pop-WindowsNotification -Body $Body -Title $Title -Icon $Icon
             break
         }
     }


### PR DESCRIPTION
Windows was feeling left out, added calls to that from the public function.

Both `$IsWindows` and `default` are identical, but it's possible there may be things we want to differently depending on PowerShell Core (On Windows) vs Windows PowerShell.

As an aside, pretty nice seeing them separated by PowerShell edition in the Action Center:

![Toast in action centre](https://user-images.githubusercontent.com/6955786/49397884-b4ce1480-f7a1-11e8-88c6-d9c268a9e1ae.png)