### PR TITLE
Required modules based on core vs desktop

### DIFF
--- a/src/PoshNotify.psd1
+++ b/src/PoshNotify.psd1
@@ -51,7 +51,7 @@ PowerShellVersion = '5.1'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @('MacNotify', 'PSNotifySend')
+RequiredModules = if ($PSEdition -eq 'Core') {'MacNotify', 'PSNotifySend'} else { '' }
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
In response to #12 this gets us part way through the issue.

On desktop (Windows PowerShell) the two dependencies aren't enforced, but on Core (on Windows) they are.

I could only make `$PSEdition` work, so couldn't check against `$IsLinux` to make things more granular.

... Can someone test this out on Linux and Mac?