### PR TITLE
Fix logic in PSM1 for updating modules for Mac and Linux if existing.

### DIFF
--- a/src/PoshNotify.psm1
+++ b/src/PoshNotify.psm1
@@ -2,8 +2,16 @@ if($IsMacOS -and !(Get-Module MacNotify -list)) {
     Install-Module MacNotify
 }
 
+if($IsMacOS -and (Get-Module MacNotify -list)) {
+    Update-Module MacNotify
+}
+
 if($IsLinux -and !(Get-Module PSNotifySend -list)) {
     Install-Module PSNotifySend
+}
+
+if($IsLinux -and (Get-Module PSNotifySend -list)) {
+    Update-Module PSNotifySend
 }
 
 #Get public and private function definition files.


### PR DESCRIPTION
Since I made the change to PSNotifySend users with the module already installed won't get the update, keeping their module broken.

While this won't fix things straight away for them, after they update to the new release of this, things will stay unbroken if we make changes to the modules we wrap this around.